### PR TITLE
fix: Update atsumaruResBaseUrl

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "atsumaruBaseUrl": "https://game.nicovideo.jp",
-  "atsumaruResBaseUrl": "https://html5.nicogame.jp",
+  "atsumaruResBaseUrl": "https://resource.game.nicovideo.jp",
   "atsumaruHostName": "game.nicovideo.jp",
   "accountHostName": "account.nicovideo.jp"
 }


### PR DESCRIPTION
いつからかは分からないのですが、アツマールのゲームのiframeの先のurlが `html5.nicogame.jp` ではなく `https://resource.game.nicovideo.jp` に変更されていて、また `html5.nicogame.jp` のSSL証明書の有効期限が切れてしまったようで、atsumaru debuggerが動かなくなっていたので、修正してみました。